### PR TITLE
Make `@importmeta` search the module path.

### DIFF
--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -111,9 +111,8 @@ end
 module B
 using  ExpressionPatterns.Dispatch
 using  ExpressionPatterns.Dispatch.MetaUtilities
-import ..A.A
 
-  @importmeta A.@f
+  @importmeta Main.Tests.ReflectionTests.A.@f
 
   @macromethod f(x+y) (x,y)
   @macromethod g(x+y) (x,y)


### PR DESCRIPTION
Before, `@importmeta M.m` would look for M in the current module. This makes it consistent with `import`.