### PR TITLE
Fix bug when a simple slurp has a constant binding

### DIFF
--- a/src/Analyzer/Function.jl
+++ b/src/Analyzer/Function.jl
@@ -79,7 +79,7 @@ function analyze_args!(args, node, state)
   for i in eachindex(args)
     analyze!(args[i], nstate)
   end
-  optimize_slurps!(node)
+  optimize_slurps!(node, state)
 end
 
 #-----------------------------------------------------------------------------------

--- a/src/Analyzer/SlurpOptimizations.jl
+++ b/src/Analyzer/SlurpOptimizations.jl
@@ -9,22 +9,22 @@ export optimize_slurps!
 # dispatch function
 #-----------------------------------------------------------------------------------
 
-function optimize_slurps!(node)
+function optimize_slurps!(node, state)
   slurps = reverse(find(is_slurp, node.children))
-  optimize_slurps!(node, slurps, [])
+  optimize_slurps!(node, slurps, [], state)
 end
 
-function optimize_slurps!(node, slurps, after)
+function optimize_slurps!(node, slurps, after, state)
   isempty(slurps) && return
 
   i = slurps[1]
   slurp = node.children[i]
 
   if isempty(after) # last slurp
-    if is_simple_slurp(slurp)
+    if is_simple_slurp(slurp, state)
        node.children[i] = make_simple_last_slurp(slurp, node, i)
 
-    elseif is_simple_alternating_slurp(slurp)
+    elseif is_simple_alternating_slurp(slurp, state)
       # simple alternating last slurp | (..., *{a,b,c..})
     end
   else
@@ -34,17 +34,17 @@ function optimize_slurps!(node, slurps, after)
     if !isempty(equals)
       eqvalues = map(j->(node.children[i+j].check.value, i+j), equals)
 
-      if is_simple_slurp(slurp)
+      if is_simple_slurp(slurp, state)
         until, index = eqvalues[1]
         node.children[i] = make_simple_slurp_until_one(slurp, node, until, index-i)
         
-      elseif is_simple_alternating_slurp(slurp)
+      elseif is_simple_alternating_slurp(slurp, state)
 	# alternating slurp until X | (..., *{a,b,c...}, X, ...)
       end
     end
   end
   push!(after, i)
-  optimize_slurps!(node, slurps[2:end], after)
+  optimize_slurps!(node, slurps[2:end], after, state)
 end
 
 #-----------------------------------------------------------------------------------
@@ -67,14 +67,16 @@ make_simple_slurp_until_one(slurp, node, until, index) =
 # conditions
 #-----------------------------------------------------------------------------------
 
-function is_simple_slurp(slurp)
+function is_simple_slurp(slurp, state)
   length(slurp.children) == 1 &&
-  is_binding(slurp.children[1])
+  is_binding(slurp.children[1]) &&
+  !is_const_binding(slurp.children[1], state)
 end
 
-function is_simple_alternating_slurp(slurp)
+function is_simple_alternating_slurp(slurp, state)
   length(slurp.children) > 1 &&
-  all(is_binding, slurp.children)
+  all(is_binding, slurp.children) &&
+  !is_const_binding(slurp.children[1], state)
 end
 
 function is_binding(node::PatternGate)
@@ -82,5 +84,9 @@ function is_binding(node::PatternGate)
   isa(node.child, PatternLeaf)
 end
 is_binding(x) = false
+
+function is_const_binding(node::PatternGate, state)
+  node.check.name in state.consts
+end
 
 end

--- a/test/matching.jl
+++ b/test/matching.jl
@@ -141,6 +141,11 @@ end
   :(1,2) => false
 end
 
+@testmatch :(*{:C{x}},) begin
+  :(1,1,1,1,1) => true
+  :(1,1,1,1,2) => false
+end
+
 # equality
 
 @testmatch :(:EQ{x, 10}) begin


### PR DESCRIPTION
`:(*{:C{x}},)` used to match any sequence of elements, instead of a sequence of the same element.