### PR TITLE
Mark the package as precompilable.

### DIFF
--- a/src/ExpressionPatterns.jl
+++ b/src/ExpressionPatterns.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module ExpressionPatterns
 export @metadispatch, @metadestruct
 


### PR DESCRIPTION
I don't think I need a `__init__` function, so I guess this is all I have to do?