### PR TITLE
Workaround for julia `"doc" at-m` issue.

### DIFF
--- a/src/Docs/Destructuring.jl
+++ b/src/Docs/Destructuring.jl
@@ -36,7 +36,7 @@ code;
 #----------------------------------------------------------------------------
 # Destructuring.Applications;
 #----------------------------------------------------------------------------
-import ..Destructuring.Applications: @letds, @macrods, @anonds, @funds
+import ..Destructuring.Applications: @letds, @macrods, @anonds, @funds, Applications
 
 """
 ```julia
@@ -64,7 +64,7 @@ end
 ```
 
 """
-:@letds;
+:(Applications.@letds);
 
 """
 ```julia
@@ -86,7 +86,7 @@ examples:
 ```
 
 """
-:@macrods;
+:(Applications.@macrods);
 
 """
 ```julia
@@ -108,7 +108,7 @@ examples:
 ```
 
 """
-:@macrods;
+:(Applications.@macrods);
 
 """
 ```julia
@@ -132,7 +132,7 @@ last_index(ex)  == 7
 ```
 
 """
-:@anonds;
+:(Applications.@anonds);
 
 """
 ```julia
@@ -152,4 +152,4 @@ extract_int(:[a,b,4,d,e,f,g]) == 4
 ```
 
 """
-:@funds;
+:(Applications.@funds);

--- a/src/Docs/Dispatch.jl
+++ b/src/Docs/Dispatch.jl
@@ -166,7 +166,7 @@ import_metatable;
 #-----------------------------------------------------------------------------------
 # Dispatch.Applications;
 #-----------------------------------------------------------------------------------
-import ..Dispatch.Applications: @macromethod, @metafunction, @metadestruct, @metadispatch
+import ..Dispatch.Applications: @macromethod, @metafunction, @metadestruct, @metadispatch, Applications
 
 """
 `@macromethod name(patterns...) body`  
@@ -176,7 +176,7 @@ Creates a extensible macro that matches and destructures the given patterns.
 
 For examples see the [`/examples`](../../examples) directory or the [dispatch tests](../../test/dispatch.jl).
 """
-:@macromethod;
+:(Applications.@macromethod);
 
 """
 `@metafunction name(patterns...) body`  
@@ -187,7 +187,7 @@ Creates a function that dispatches on expression patterns.
 For examples see the [`/examples`](../../examples) directory or the [dispatch tests](../../test/dispatch.jl).
 
 """
-:@metafunction;
+:(Applications.@metafunction);
 
 """
 `@metadestruct let ...;  ... end`  
@@ -205,7 +205,7 @@ Related:
 - `@funds`
 
 """
-:@metadestruct;
+:(Applications.@metadestruct);
 
 """
 `@metadispatch macro m(...) ... end`  
@@ -219,12 +219,12 @@ Related:
 - `@metafunction`
 
 """
-:@metadispatch;
+:(Applications.@metadispatch);
 
 #-----------------------------------------------------------------------------------
 # Dispatch.MetaModule;
 #-----------------------------------------------------------------------------------
-import ..Dispatch.MetaModule: @metamodule
+import ..Dispatch.MetaModule: @metamodule, MetaModule
 
 """
 `@metamodule import Module.Path.name`
@@ -260,4 +260,4 @@ Exports the metatable `name` from the current module M so that `@metamodule impo
 Import all exported metatables from `Module.Path`.
 
 """
-:@metamodule;
+:(MetaModule.@metamodule);

--- a/src/Docs/Helper.jl
+++ b/src/Docs/Helper.jl
@@ -2,7 +2,7 @@
 # Helper;
 #-----------------------------------------------------------------------------------
 import ..Helper: Looping, current, next!, restart!, @implicit,
-         unzip, remove, is_line_number, linesof, exprmodify
+         unzip, remove, is_line_number, linesof, exprmodify, Helper
 
 
 """
@@ -92,7 +92,7 @@ end
 ```
 
 """
-:@implicit;
+:(Helper.@implicit);
 
 
 """

--- a/src/Docs/makedocs.jl
+++ b/src/Docs/makedocs.jl
@@ -71,7 +71,8 @@ function make_file_doc(filename)
     while modtext != ""
       fhelp, modtext = capture(modtext, from="\"\"\"", until="\"\"\"")
       fname, modtext = capture(modtext, from="", until=";")
-      fname  = replace(strip(fname), ":@", "@")
+      fname  = replace(strip(fname), r":\(.*@", "@")
+      fname  = replace(strip(fname), ")", "")
       fname != "" && push!(fdocs, FuncDoc(fname, fhelp, strip(mname), filename[1:end-3]))
     end
     push!(mods, ModDoc(strip(mname), fdocs, filename[1:end-3]))


### PR DESCRIPTION
Currently julia can't document imported macros directly
(JuliaLang/julia#12700), so this is a workaround. Will revert once
that's fixed.