### PR TITLE
Fix travis version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
Maybe if I wait a bit `release` will become 0.5, but I just those deprecation warnings gone already!!