### PR TITLE
Julia v0.6 deprecations 2

### DIFF
--- a/examples/classprep.jl
+++ b/examples/classprep.jl
@@ -50,7 +50,7 @@ end
 class_field_values(obj) =
   filter(x->!isa(x, Method), map(x->getfield(obj, x), fieldnames(obj)))
 
-function Base.show{T <: Object}(io::IO, obj::T)
+function Base.show(io::IO, obj::T) where T<:Object
   print("$T(")
 
   fields = class_field_values(obj)

--- a/src/Matching/Comparison.jl
+++ b/src/Matching/Comparison.jl
@@ -82,7 +82,7 @@ function compare_checks(a::PredicateCheck, b::PredicateCheck, vars1, vars2)
   a.predicate == b.predicate? :equal : :unequal
 end
 
-function compare_checks{T1,T2}(a::TypeCheck{T1}, b::TypeCheck{T2}, vars1, vars2)
+function compare_checks(a::TypeCheck{T1}, b::TypeCheck{T2}, vars1, vars2) where T1 where T2
   T1 == T2? :equal    :
   T2 <: T1? :superset :
   T1 <: T2? :subset   :

--- a/src/Matching/Function.jl
+++ b/src/Matching/Function.jl
@@ -59,9 +59,9 @@ function match_check(bd::Binding, ex, st)
   st.inslurp? true :  match_variable!(st.variables, bd.name, ex)
 end
 
-match_check{T}(check::EqualityCheck{T}, ex::T, st) = check.value == ex
-match_check{T}(check::TypeCheck{T},     ex::T, st) = true
-match_check(check::PredicateCheck,      ex,    st) = check.predicate(ex)
+match_check(check::EqualityCheck{T}, ex::T, st) where T = check.value == ex
+match_check(check::TypeCheck{T},     ex::T, st) where T = true
+match_check(check::PredicateCheck,   ex,    st) = check.predicate(ex)
 
 match_check(check, ex, st) = false
 

--- a/test/matching.jl
+++ b/test/matching.jl
@@ -74,7 +74,7 @@ end
 
 # block
 
-@testmatch (quote *{:T{:P{islower}, AbstractString}} end) begin
+@testmatch (quote *{:T{:P{s->all(islower,s)}, AbstractString}} end) begin
   (quote "abc"; "onetwothree"; "solami" end) => true
   (quote "abc";     "123";     "solami" end) => false
   (quote "abc"; "onetwothree"; "solami" end) => true


### PR DESCRIPTION
Mostly `{T}` => `where T` with a lone `islower` which I had to change to `s->all(islower, s)` which is way uglier but wHATEVER. I AM NOT MAD ABOUT THAT.