### PR TITLE
Adapt to 0.7 macrocall changes

### DIFF
--- a/src/Analyzer/Function.jl
+++ b/src/Analyzer/Function.jl
@@ -48,7 +48,8 @@ function analyze!(ex::Symbol, state)
 end
 
 function analyze!(ex::Expr, state)
-  is_special_expr(ex) && (analyze_special!(ex, state); return)
+  is_special_expr(ex) && (return analyze_special!(ex, state))
+  ex.head == :line && (return analyze!(LineNumberNode(0), state))
 
   step = getstep(ex.head)
   head = ex.head in [:kw, :(=)]? :assign : ex.head
@@ -62,6 +63,10 @@ function analyze!(ex::QuoteNode, state)
   step = QuoteStep()
   node = newnode!(ExprHead(:quote), step, state.tree)
   analyze!(ex.value, newstate(state, node))
+end
+
+function analyze!(ex::LineNumberNode, state)
+  analyze_special!(:(:P{$Helper.is_line_number}), state)
 end
 
 function analyze!(ex, state)

--- a/src/Dispatch/MetaModule.jl
+++ b/src/Dispatch/MetaModule.jl
@@ -57,7 +57,7 @@ function importallcode(path)
 
     for exp in $union(metafun_exports, macromet_exports)
       imp = Expr(:import, $vcat($path, exp)...)
-      eval(Expr(:macrocall, Symbol("@metamodule"), imp))
+      eval($macrocall_ex("@metamodule", imp))
     end
   end
 end
@@ -69,5 +69,10 @@ end
 gettable(name) =
   startswith(string(name), "@")? MM : MF
 
+function macrocall_ex(name, args...)
+  ex = :(@x $(args...))
+  ex.args[1] = Symbol(name)
+  ex
+end
 
 end


### PR DESCRIPTION
The main change is that this makes line-number-nodes compare by type instead of value, which I think is better overall anyway, I don't see people comparing LineNumberNodes by value often. (and they still can anyway with `:equals`)

This fixes the tests on 0.7-dev.