### PR TITLE
Fix 0.7 question mark deprecation

### DIFF
--- a/docs/Language.md
+++ b/docs/Language.md
@@ -38,7 +38,7 @@ x = :symbol; :(EQ{x})  # matches :symbol. Note that equals\E\EQ calls eval on it
 Slurps
 -------
 
-A slurp works like `*` quantifiers in regular expressions, matching 0 or more of the pattern with the arguments of an expression. They are created with `*{p}` (greedy, matches as much as possible) or `?{p}` (lazy, match as little as possible). Slurps can have multiple arguments, e.g. `*{a,b,c}`, and in this case each argument is matched in a looping sequence, e.g. when matching `[*{a,b,c}]` with       `:[1,2,3,4,5,6]`, `a` is matched with `1`, b with `2`, `c` with `3`, then `a` with `4`, `b` with `5` and `c` with `6`. Note that if the expression had been `:[1,2,3,4,5]` the match would fail, since every subpattern must match for a loop to count.  
+A slurp works like `*` quantifiers in regular expressions, matching 0 or more of the pattern with the arguments of an expression. They are created with `*{p}` (greedy, matches as much as possible) or `:?{p}` (lazy, match as little as possible). Slurps can have multiple arguments, e.g. `*{a,b,c}`, and in this case each argument is matched in a looping sequence, e.g. when matching `[*{a,b,c}]` with       `:[1,2,3,4,5,6]`, `a` is matched with `1`, b with `2`, `c` with `3`, then `a` with `4`, `b` with `5` and `c` with `6`. Note that if the expression had been `:[1,2,3,4,5]` the match would fail, since every subpattern must match for a loop to count.  
 
 Slurps can be nested: `[*{[*{1,2}]}]` matches expressions like `:[[1,2,1,2], [1,2], [1,2,1,2,1,2]]`. In destructuring, `[*{[*{x,y}]}]` will have `x` and `y` be vectors of vectors, e.g. `[*{[*{x,y}]}] = :[[1,2,1,2], [1,2], [1,2,1,2,1,2]] -> x=[[1,1], [1], [1,1,1,1], y=[[2,2], [2], [2,2,2,2]]`. If `x` was within three slurps, it would have been a vector of vectors of vectors, etc.
 
@@ -49,9 +49,9 @@ Slurps can be nested: `[*{[*{1,2}]}]` matches expressions like `:[[1,2,1,2], [1,
 
 :[*{odd,even}]       # matches :[1,2,3,4,5,6], x=[1,3,5], y=[2,4,6]
 
-:[*{x},?{y}]         # matches :[1,2,3,4], x=[1,2,3,4], y=[]
+:[*{x},:?{y}]        # matches :[1,2,3,4], x=[1,2,3,4], y=[]
 
-:[?{x},*{y}]         # matches :[1,2,3,4], x=[], y=[1,2,3,4]
+:[:?{x},*{y}]        # matches :[1,2,3,4], x=[], y=[1,2,3,4]
 
 :(f(*{:T{Symbol}}))  # matches :(f(x,y)), :("g"(a,b,c)), but not :(f(1,2)) or :(g(a,b,3))
 

--- a/docs/lib/Destructuring.md
+++ b/docs/lib/Destructuring.md
@@ -92,8 +92,8 @@ examples:
 extremes = @anonds [first, *{middle}, last] -> (first, last)
 extremes(:[1,2,3,4]) == (1,4)
 
-first_index = @anonds (:C{i} => [?{x}, i, *{a}]) -> length(x)+1
-last_index  = @anonds (:C{i} => [*{x}, i, *{a}]) -> length(x)+1
+first_index = @anonds (:C{i} => [:?{x}, i, *{a}]) -> length(x)+1
+last_index  = @anonds (:C{i} => [*{x},  i, *{a}]) -> length(x)+1
 
 ex = :(0 => [1,1,1,0,1,1,0])
 first_index(ex) == 4

--- a/examples/classprep.jl
+++ b/examples/classprep.jl
@@ -22,8 +22,8 @@ function make_constructor(name, info, constructor_info::ClassConstructor)
   args  = constructor_info.arguments
   stats = constructor_info.statements
 
-  statements  = args == :undef? map(make_def, info.undefined) : stats
-  arguments   = args == :undef? info.undefined : args
+  statements  = args == :undef ? map(make_def, info.undefined) : stats
+  arguments   = args == :undef ? info.undefined : args
   param_defs  = constructor_info.param_defs
   method_defs = constructor_info.method_defs
   new_args    = constructor_info.new_args

--- a/examples/switch.jl
+++ b/examples/switch.jl
@@ -11,7 +11,7 @@ macro switch(value, block)
     end)
 end
 
-@metafunction switch(value, begin :L{:case}(x); ?{xs}; :L{:case}(y); *{ys} end) begin
+@metafunction switch(value, begin :L{:case}(x); :?{xs}; :L{:case}(y); *{ys} end) begin
   next = switch(value, quote :case($y); $(ys...) end)
   switch_clause(value, x, xs, next)
 end

--- a/examples/switch_fallout.jl
+++ b/examples/switch_fallout.jl
@@ -11,7 +11,7 @@ macro switch(value, block)
     end)
 end
 
-@metafunction switch(value, begin :L{:case}(x); ?{xs}; :L{:case}(y); *{ys} end) begin
+@metafunction switch(value, begin :L{:case}(x); :?{xs}; :L{:case}(y); *{ys} end) begin
   @gensym label
   nextclauses, nextstatements = switch(value, quote :case($y); $(ys...) end)
   clauses    = switch_clause(value, x, label, nextclauses)

--- a/src/Analyzer/Function.jl
+++ b/src/Analyzer/Function.jl
@@ -41,7 +41,7 @@ end
 #-----------------------------------------------------------------------------------
 
 function analyze!(ex::Symbol, state)
-  is_binding_name(ex) && !state.literal?
+  is_binding_name(ex) && !state.literal ?
      newleaf!(newbinding(ex), state.tree) :
      newleaf!(equalsto(ex),   state.tree)
   #--
@@ -52,7 +52,7 @@ function analyze!(ex::Expr, state)
   ex.head == :line && (return analyze!(LineNumberNode(0), state))
 
   step = getstep(ex.head)
-  head = ex.head in [:kw, :(=)]? :assign : ex.head
+  head = ex.head in [:kw, :(=)] ? :assign : ex.head
   node = newnode!(ExprHead(head), step, state.tree)
   args = step(ex)
 
@@ -176,8 +176,8 @@ end
 #-----------------------------------------------------------------------------------
 
 function getstep(head)
-  head == :quote? QuoteStep() :
-  head == :block? BlockStep() :
+  head == :quote ? QuoteStep() :
+  head == :block ? BlockStep() :
                   ArgsStep()
 end
 
@@ -186,7 +186,7 @@ function is_macro_name(x::Symbol)
 end
 
 function newbinding(ex)
-  name = is_macro_name(ex)? Symbol(string(ex)[2:end]) : ex
+  name = is_macro_name(ex) ? Symbol(string(ex)[2:end]) : ex
   Binding(name)
 end
 
@@ -199,7 +199,7 @@ end
 equalsto(x) = EqualityCheck(x)
 
 assertation_args(args) =
-  length(args) == 1? [gensym("x"), args[1]] : args
+  length(args) == 1 ? [gensym("x"), args[1]] : args
 
 #-----------------------------------------------------------------------------------
 

--- a/src/Analyzer/Function.jl
+++ b/src/Analyzer/Function.jl
@@ -96,8 +96,8 @@ function analyze_special!(ex, state)
   head = special_name(ex.args[1])
   args = ex.args[2:end]
 
-  if head in [:(?), :(*)]
-    slurptype = head == :(?)? GenericLazySlurp() : GenericGreedySlurp()
+  if head in [:?, :*]
+    slurptype = head == :? ? GenericLazySlurp() : GenericGreedySlurp()
 
     node = newnode!(slurptype, SlurpStep(), state.tree)
     analyze_args!(args, node, state)

--- a/src/Analyzer/SlurpOptimizations.jl
+++ b/src/Analyzer/SlurpOptimizations.jl
@@ -59,7 +59,7 @@ make_simple_last_slurp(slurp, node, i) =
 
 make_simple_slurp_until_one(slurp, node, until, index) =
   make_slurp(slurp,
-              isa(slurp.head, GreedySlurp)?
+              isa(slurp.head, GreedySlurp) ?
                 SimpleGreedySlurpUntil([until], index) :
                 SimpleLazySlurpUntil([until], index))
 

--- a/src/Destructuring/Applications.jl
+++ b/src/Destructuring/Applications.jl
@@ -48,7 +48,7 @@ end
 end
 
 anonds(p::Symbol, body) = anonds_impl(:($p,), body)
-anonds(p::Expr,  body)  = anonds_impl(p.head == :tuple? p : :($p,), body)
+anonds(p::Expr,  body)  = anonds_impl(p.head == :tuple ? p : :($p,), body)
 
 function anonds_impl(patterns, body)
   :((args...) ->

--- a/src/Dispatch/BaseImplementations.jl
+++ b/src/Dispatch/BaseImplementations.jl
@@ -11,8 +11,8 @@ function show(io::IO, met::MetaMethod)
     s = replace(s, r"pattern{.*?}<", "", 1)[1:end-1]
   end
   consts  = match(r"pattern{consts: (.*?)}", sprint(show, met.tree))
-  consts  = isa(consts, Void)? "" : consts[1]
-  label   = met.label == unlabeled? "[---]" : "[$(met.label)]"
+  consts  = isa(consts, Void) ? "" : consts[1]
+  label   = met.label == unlabeled ? "[---]" : "[$(met.label)]"
 
   (print(io, label, "{$consts}<"))
   [print(io, arg,   " ") for arg in args[1:end-1]]

--- a/src/Dispatch/MetaModule.jl
+++ b/src/Dispatch/MetaModule.jl
@@ -67,7 +67,7 @@ end
 #-----------------------------------------------------------------------------------
 
 gettable(name) =
-  startswith(string(name), "@")? MM : MF
+  startswith(string(name), "@") ? MM : MF
 
 function macrocall_ex(name, args...)
   ex = :(@x $(args...))

--- a/src/Dispatch/Reflection.jl
+++ b/src/Dispatch/Reflection.jl
@@ -16,7 +16,7 @@ metafuntable(funname,M) =
   get_metatable(METAFUNCTIONS, M, funname)
 
 gettable(typ, m) =
-  typ == :macro?
+  typ == :macro ?
     M -> macrotable(m, M) :
     M -> metafuntable(m, M)
 

--- a/src/Dispatch/TableManipulation.jl
+++ b/src/Dispatch/TableManipulation.jl
@@ -135,7 +135,7 @@ function prefermethod_impl!(table, tree1, tree2)
     insert!(methods, j, method)
     table
   else
-    sig = i == 0? tree1 : tree2
+    sig = i == 0 ? tree1 : tree2
     notfounderror(table, "signature $(sig)")
   end
 end
@@ -149,7 +149,7 @@ notfounderror(table, key) =
 
 function whichmethod(table, parameters)
   i = findnext(met->met.matcher(parameters), table.methods, 1)
-  i == 0? nothing : table.methods[i]
+  i == 0 ? nothing : table.methods[i]
 end
 
 #----------------------------------------------------------------------------

--- a/src/Docs/Destructuring.jl
+++ b/src/Docs/Destructuring.jl
@@ -100,8 +100,8 @@ examples:
 extremes = @anonds [first, *{middle}, last] -> (first, last)
 extremes(:[1,2,3,4]) == (1,4)
 
-first_index = @anonds (:C{i} => [?{x}, i, *{a}]) -> length(x)+1
-last_index  = @anonds (:C{i} => [*{x}, i, *{a}]) -> length(x)+1
+first_index = @anonds (:C{i} => [:?{x}, i, *{a}]) -> length(x)+1
+last_index  = @anonds (:C{i} => [*{x},  i, *{a}]) -> length(x)+1
 
 ex = :(0 => [1,1,1,0,1,1,0])
 first_index(ex) == 4

--- a/src/Docs/makedocs.jl
+++ b/src/Docs/makedocs.jl
@@ -146,7 +146,7 @@ function prepare_text(text)
 end
 
 filepath(filedoc, dir) =
-  dir == pwd()?
+  dir == pwd() ?
     joinpath("lib", "$(filedoc.name).md") :
     joinpath(dir, "lib", "$(filedoc.name).md")
 

--- a/src/Helper/Helper.jl
+++ b/src/Helper/Helper.jl
@@ -109,10 +109,10 @@ exprmodify(modify; on=always) =
   ex -> exprmodify(modify, ex, on=on)
 
 exprmodify(modify, ex; on=always) =
-  on(ex)? modify(ex) : ex
+  on(ex) ? modify(ex) : ex
 
 exprmodify(modify, ex::Expr; on=always) =
-  on(ex)? modify(ex) : Expr(ex.head, map(exprmodify(modify, on=on), ex.args)...)
+  on(ex) ? modify(ex) : Expr(ex.head, map(exprmodify(modify, on=on), ex.args)...)
 
 function clean_code(ex::Expr)
   nex = Expr(ex.head, map(clean_code, ex.args)...)

--- a/src/Matching/Comparison.jl
+++ b/src/Matching/Comparison.jl
@@ -47,18 +47,18 @@ end
 
 function compare_trees(a::PatternGate, b::PatternGate, vars1, vars2)
   checks =  compare_checks(a.check, b.check, vars1, vars2)
-  checks == :equal?
+  checks == :equal ?
      compare_trees(a.child, b.child, vars1, vars2) : checks
 end
 
 function compare_trees(a::PatternGate, b, vars1, vars2)
   checks =  compare_checks(a.check, b, vars1, vars2)
-  checks == :superset? :superset : :unequal
+  checks == :superset ? :superset : :unequal
 end
 
 function compare_trees(a, b::PatternGate, vars1, vars2)
   checks =  compare_checks(a, b.check, vars1, vars2)
-  checks == :subset? :subset : :unequal
+  checks == :subset ? :subset : :unequal
 end
 
 function compare_checks(a::Binding, b::Binding, vars1, vars2)
@@ -67,25 +67,25 @@ function compare_checks(a::Binding, b::Binding, vars1, vars2)
 end
 
 function compare_checks(a::Binding, b, vars1, vars2)
-  match_variable!(vars1, a.name, b)? :superset : :unequal
+  match_variable!(vars1, a.name, b) ? :superset : :unequal
 end
 
 function compare_checks(a, b::Binding, vars1, vars2)
-  match_variable!(vars2, b.name, a)? :subset : :unequal
+  match_variable!(vars2, b.name, a) ? :subset : :unequal
 end
 
 function compare_checks(a::EqualityCheck, b::EqualityCheck, vars1, vars2)
-  a.value == b.value? :equal : :unequal
+  a.value == b.value ? :equal : :unequal
 end
 
 function compare_checks(a::PredicateCheck, b::PredicateCheck, vars1, vars2)
-  a.predicate == b.predicate? :equal : :unequal
+  a.predicate == b.predicate ? :equal : :unequal
 end
 
 function compare_checks(a::TypeCheck{T1}, b::TypeCheck{T2}, vars1, vars2) where T1 where T2
-  T1 == T2? :equal    :
-  T2 <: T1? :superset :
-  T1 <: T2? :subset   :
+  T1 == T2 ? :equal    :
+  T2 <: T1 ? :superset :
+  T1 <: T2 ? :subset   :
             :unequal
 end
 compare_checks(a, b, vars1, vars2) = :unequal

--- a/src/Matching/Environment.jl
+++ b/src/Matching/Environment.jl
@@ -11,7 +11,7 @@ const Variables   = Dict{Symbol, Any}
 const SlurpRanges = Dict{PatternNode, Vector{Range}}
 
 function match_variable!(v::Variables, name::Symbol, value)
-  haskey(v, name)?
+  haskey(v, name) ?
     (v[name] == value) :
     (v[name] =  value; true)
 end

--- a/src/Matching/Function.jl
+++ b/src/Matching/Function.jl
@@ -56,7 +56,7 @@ end
 #----------------------------------------------------------------------------
 
 function match_check(bd::Binding, ex, st)
-  st.inslurp? true :  match_variable!(st.variables, bd.name, ex)
+  st.inslurp ? true :  match_variable!(st.variables, bd.name, ex)
 end
 
 match_check(check::EqualityCheck{T}, ex::T, st) where T = check.value == ex
@@ -81,7 +81,7 @@ function match_children(node, args, ci, ai, st)
 end
 
 function match_child(node, args, ci, ai, slurpchild, st)
-  is_slurp(node.children[ci])?
+  is_slurp(node.children[ci]) ?
     (match_slurp(node, args, ci, ai, slurpchild, st)) :
     (match_nonslurp_child(node, args, ci, ai, st), ai+1)
   #end
@@ -102,7 +102,7 @@ function match_slurp(node, args, ci, ai, slurpchild, st)
   local matches, mi
 
   slurp  = node.children[ci]
-  mstate = st.inslurp? st : enterslurp(st)
+  mstate = st.inslurp ? st : enterslurp(st)
 
   if ai <= length(args)
      s_info = SlurpInfo(slurp, node, slurp.children, ci, ai, st, mstate)
@@ -200,7 +200,7 @@ function slurp_until(found, slurp, args, si)
         !matches(found)
     found = found[2:end]
   end
-  return !isempty(found), isempty(found)? 0 : found[1]-si+1
+  return !isempty(found), isempty(found) ? 0 : found[1]-si+1
 end
 
 function match_slurp_impl(h::SimpleGreedySlurpUntil, slurp, args)
@@ -223,7 +223,7 @@ match_nested_slurp(node) =
 
 const Iterable = Union{Vector, Tuple}
 
-exprhead(ex::Expr)      = ex.head in [:kw, :(=)]? :assign : ex.head
+exprhead(ex::Expr)      = ex.head in [:kw, :(=)] ? :assign : ex.head
 exprhead(ex::QuoteNode) = :quote
 exprhead(ex::Iterable)  = :iterable
 exprhead(ex::Any)       = :notexpr

--- a/src/PatternStructure/Printing.jl
+++ b/src/PatternStructure/Printing.jl
@@ -20,17 +20,17 @@ function expr(p::PatternNode)
      children[1] = Symbol("@$(children[1])")
   end
 
-  is_special(p)?
+  is_special(p) ?
      Expr(:curly, QuoteNode(patterntype(p)), children...) :
      Expr(p.head.sym, children...)
 
 end
 
 function expr(p::PatternGate)
-  isa(p.check, Binding)?        p.check.name  :
-  isa(p.check, EqualityCheck)?  p.check.value :
-  isa(p.check, TypeCheck)?      :(:type{$(expr(p.child)), $(typeof(p.check).parameters[1])}) :
-  isa(p.check, PredicateCheck)? :(:predicate{$(expr(p.child)), $(p.check.predicate)}) :
+  isa(p.check, Binding) ?        p.check.name  :
+  isa(p.check, EqualityCheck) ?  p.check.value :
+  isa(p.check, TypeCheck) ?      :(:type{$(expr(p.child)), $(typeof(p.check).parameters[1])}) :
+  isa(p.check, PredicateCheck) ? :(:predicate{$(expr(p.child)), $(p.check.predicate)}) :
   throw(ArgumentError("invalid check type in PatternGate: $(p.check)"))
 end
 

--- a/src/PatternStructure/Special.jl
+++ b/src/PatternStructure/Special.jl
@@ -35,7 +35,7 @@ slurptype(node::PatternNode) =
     "Couldn't determine the slurp type of the pattern node $(node.head)"))
 
 patterntype(node::PatternNode) =
-  is_slurp(node)? slurptype(node) : node.head
+  is_slurp(node) ? slurptype(node) : node.head
 
 extract_name(x::QuoteNode) = x.value
 extract_name(x) = x

--- a/src/PatternStructure/Special.jl
+++ b/src/PatternStructure/Special.jl
@@ -29,8 +29,8 @@ is_special(node::PatternNode) = node.head in special_heads || is_slurp(node)
 is_special(x) = false
 
 slurptype(node::PatternNode) =
-  isa(node.head, LazySlurp)   ? (:(?)) :
-  isa(node.head, GreedySlurp) ? (:(*)) :
+  isa(node.head, LazySlurp)   ? :? :
+  isa(node.head, GreedySlurp) ? :* :
   throw(ArgumentError(
     "Couldn't determine the slurp type of the pattern node $(node.head)"))
 
@@ -44,10 +44,15 @@ special_name(x)       = extract_name(get(special_shortcuts, x, x))
 special_name(x::Expr) = special_name(QuoteNode(x.args[1]))
 
 function is_special_expr(ex::Expr)
+  if ex.head == :curly && ex.args[1] == :?
+    warn("?{...} is deprecated, use :?{...}")
+    ex.args[1] = :(:?)
+  end
+
   ex.head == :curly &&
     (isa(ex.args[1], QuoteNode) ||
     (isexpr(ex.args[1], :quote) ||
-    (ex.args[1] in [:(?), :(*)])))
+    (ex.args[1] in [:(:?), :(*)])))
 end
 
 

--- a/src/PatternStructure/Trees.jl
+++ b/src/PatternStructure/Trees.jl
@@ -61,7 +61,7 @@ const SingleChildNode = Union{PatternGate, PatternRoot}
 #-----------------------------------------------------------------------------------
 
 function nodehead(node::PatternNode)
-  isa(node.head, ExprHead)? node.head.sym : (:slurp)
+  isa(node.head, ExprHead) ? node.head.sym : (:slurp)
 end
 
 bindings(leaf::PatternLeaf) = Set{Symbol}()
@@ -76,7 +76,7 @@ depth(node::PatternNode) = node.depth
 function makenode(head, step, depth)
   children   = PatternTree[]
   bindings   = Set{Symbol}()
-  slurpdepth = isa(head, SlurpHead)? depth+1 : depth
+  slurpdepth = isa(head, SlurpHead) ? depth+1 : depth
 
   PatternNode(head, step, children, bindings, slurpdepth)
 end

--- a/test/matching.jl
+++ b/test/matching.jl
@@ -92,7 +92,7 @@ end
 
 # while loop / lazy slurps
 
-@testmatch :(while x < t; ?{p(?{args})}; x+=1 end) begin
+@testmatch :(while x < t; :?{p(:?{args})}; x+=1 end) begin
 
   :(while i <   10; println(io, i);             i+=1 end) => true
   :(while k < t-10; splice!(A,2,k); push!(B,k); k+=1 end) => true

--- a/test/slurp-optimizations.jl
+++ b/test/slurp-optimizations.jl
@@ -14,9 +14,9 @@ using  Base.Test
 
 # generic lazy
 
-@test isa(analyze(:(?{x+y,z},1+1,1,*{b})).child.children[1].head, GenericLazySlurp)
+@test isa(analyze(:(:?{x+y,z},1+1,1,*{b})).child.children[1].head, GenericLazySlurp)
 
-@macrods t2(?{x+y,z},1+1,1,*{b}) (x,y,z)
+@macrods t2(:?{x+y,z},1+1,1,*{b}) (x,y,z)
 
 @test @t2(10+2, a, 30+54, b, 53+1, c, 1+1, 1, 1+1, 1) == ([10,30,53], [2,54,1], [:a,:b,:c])
 
@@ -38,9 +38,9 @@ using  Base.Test
 
 # simple, until, lazy
 
-@test isa(analyze(:(?{a},3,*{b})).child.children[1].head, SimpleLazySlurpUntil)
+@test isa(analyze(:(:?{a},3,*{b})).child.children[1].head, SimpleLazySlurpUntil)
 
-@macrods t5(?{a},3,*{b}) a
+@macrods t5(:?{a},3,*{b}) a
 
 @test @t5(0,1,2,3,4,5,6) == [0,1,2]
 


### PR DESCRIPTION
Deprecates `?{...}` in favor of `:?{...}` and adds spaces before ternary `?`.